### PR TITLE
Upgraded Imagesharp to version 2.1 

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -11,23 +11,23 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.11
+      uses: gittools/actions/gitversion/setup@v1.1.1
       with:
           versionSpec: '5.x'
     - name: Use GitVersion
       id: gitversion # step id used as reference for output values
-      uses: gittools/actions/gitversion/execute@v0.9.11
-    - name: Setup .NET 5
+      uses: gittools/actions/gitversion/execute@v1.1.1
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.302
+        dotnet-version: '6.x'
     - name: Install dependencies
       run: dotnet restore
     - name: Build
@@ -35,7 +35,7 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --no-restore --no-build --verbosity normal
     - name: Publish
-      if: github.ref == 'refs/heads/master' && github.repository_owner == 'huysentruitw'
+      if: github.ref == 'refs/heads/master'
       shell: pwsh
       run: |
         Get-ChildItem ".\src" -Filter "*.nupkg" -R | ForEach-Object {

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Barcoder - Barcode Encoding Library
 
-[![Build status](https://github.com/huysentruitw/barcoder/actions/workflows/build-test-publish.yml/badge.svg?branch=master)](https://github.com/huysentruitw/barcoder/actions/workflows/build-test-publish.yml?query=branch%3Amaster)
+[![Build status](https://github.com/logstore/barcoder/actions/workflows/build-test-publish.yml/badge.svg?branch=master)](https://github.com/logstore/barcoder/actions/workflows/build-test-publish.yml?query=branch%3Amaster)
 
 Lightweight Barcode Encoding Library for .NET Framework, .NET Standard and .NET Core. Additional packages are available for rendering the generated barcode to SVG or an image.
 
-Code ported from the GO project https://github.com/boombuler/barcode by [Florian Sundermann](https://github.com/boombuler).
+The barcode2 is a fork of library Barcoder by [Huysentruit](https://github.com/huysentruitw).
 
 Supported Barcode Types:
 
@@ -28,17 +28,17 @@ Supported Barcode Types:
 
 ## NuGet package
 
-To install the [main package](https://www.nuget.org/packages/Barcoder):
+To install the [main package](https://www.nuget.org/packages/barcoder2):
 
-    PM> Install-Package Barcoder
+    PM> Install-Package Barcoder2
 
 To install the SVG renderer:
 
-    PM> Install-Package Barcoder.Renderer.Svg
+    PM> Install-Package Barcoder2.Renderer.Svg
 
 To install the image renderer[^1]:
 
-	PM> Install-Package Barcoder.Renderer.Image
+	PM> Install-Package Barcoder2.Renderer.Image
 	
 ## Usage - render to SVG
 

--- a/src/Barcoder.Renderer.Image/Barcoder.Renderer.Image.csproj
+++ b/src/Barcoder.Renderer.Image/Barcoder.Renderer.Image.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Title>Barcoder.Renderer.Image</Title>
+    <Title>Barcoder2.Renderer.Image</Title>
     <Description>Image Renderer for Barcoder (.NET Framework, .NET Standard and .NET Core).</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Wouter Huysentruit</Company>

--- a/src/Barcoder.Renderer.Image/Barcoder.Renderer.Image.csproj
+++ b/src/Barcoder.Renderer.Image/Barcoder.Renderer.Image.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Title>Barcoder.Renderer.Image</Title>
     <Description>Image Renderer for Barcoder (.NET Framework, .NET Standard and .NET Core).</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Wouter Huysentruit</Company>
-    <Version>1.0.0.0</Version>
+    <Version>2.0.0.0</Version>
     <Authors>Wouter Huysentruit</Authors>
     <PackageProjectUrl>https://github.com/huysentruitw/barcoder</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Barcoder.Renderer.Image/Internal/EanContentRenderer.cs
+++ b/src/Barcoder.Renderer.Image/Internal/EanContentRenderer.cs
@@ -68,7 +68,7 @@ namespace Barcoder.Renderer.Image.Internal
 
         private static void RenderBlackText(Image<L8> image, string text, float x, float y, Font font)
         {
-            var options = new TextOptions(font)
+            var options = new RichTextOptions(font)
             {
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,

--- a/src/Barcoder.Renderer.Svg/Barcoder.Renderer.Svg.csproj
+++ b/src/Barcoder.Renderer.Svg/Barcoder.Renderer.Svg.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Title>Barcoder.Renderer.Svg</Title>
     <Description>SVG Renderer for Barcoder (.NET Framework, .NET Standard and .NET Core).</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Barcoder.Renderer.Svg/Barcoder.Renderer.Svg.csproj
+++ b/src/Barcoder.Renderer.Svg/Barcoder.Renderer.Svg.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Title>Barcoder.Renderer.Svg</Title>
+    <Title>Barcoder2.Renderer.Svg</Title>
     <Description>SVG Renderer for Barcoder (.NET Framework, .NET Standard and .NET Core).</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Wouter Huysentruit</Company>
-    <Version>1.0.0.0</Version>
+    <Version>2.0.0.0</Version>
     <Authors>Wouter Huysentruit</Authors>
     <PackageProjectUrl>https://github.com/huysentruitw/barcoder</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Barcoder/Barcoder.csproj
+++ b/src/Barcoder/Barcoder.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Title>Barcoder</Title>
     <Description>Lightweight Barcode Encoding Library for .NET Framework, .NET Standard and .NET Core.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Wouter Huysentruit</Company>
-    <Version>1.0.0.0</Version>
+    <Version>2.0.0.0</Version>
     <Authors>Wouter Huysentruit</Authors>
     <PackageProjectUrl>https://github.com/huysentruitw/barcoder</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Barcoder/Barcoder.csproj
+++ b/src/Barcoder/Barcoder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Title>Barcoder</Title>
+    <Title>Barcoder2</Title>
     <Description>Lightweight Barcode Encoding Library for .NET Framework, .NET Standard and .NET Core.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Wouter Huysentruit</Company>

--- a/tests/Barcoder.Renderer.Image.Tests/Barcoder.Renderer.Image.Tests.csproj
+++ b/tests/Barcoder.Renderer.Image.Tests/Barcoder.Renderer.Image.Tests.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Barcoder.Renderer.Image.Tests/ImageRendererTests.cs
+++ b/tests/Barcoder.Renderer.Image.Tests/ImageRendererTests.cs
@@ -85,7 +85,9 @@ namespace Barcoder.Renderer.Image.Tests
 
             // Assert
             stream.Position = 0;
-            using var image = ImageSharp.Image.Load(stream, out IImageFormat imageFormat);
+            using var image = ImageSharp.Image.Load(stream);
+            stream.Position = 0;
+            IImageFormat imageFormat = ImageSharp.Image.DetectFormat(stream);
             imageFormat.Name.Should().Be("BMP");
         }
 
@@ -102,7 +104,9 @@ namespace Barcoder.Renderer.Image.Tests
 
             // Assert
             stream.Position = 0;
-            using var image = ImageSharp.Image.Load(stream, out IImageFormat imageFormat);
+            using var image = ImageSharp.Image.Load(stream);
+            stream.Position = 0;
+            IImageFormat imageFormat = ImageSharp.Image.DetectFormat(stream);
             imageFormat.Name.Should().Be("GIF");
         }
 
@@ -119,7 +123,9 @@ namespace Barcoder.Renderer.Image.Tests
 
             // Assert
             stream.Position = 0;
-            using var image = ImageSharp.Image.Load(stream, out IImageFormat imageFormat);
+            using var image = ImageSharp.Image.Load(stream);
+            stream.Position = 0;
+            IImageFormat imageFormat = ImageSharp.Image.DetectFormat(stream);
             imageFormat.Name.Should().Be("JPEG");
         }
 
@@ -136,7 +142,9 @@ namespace Barcoder.Renderer.Image.Tests
 
             // Assert
             stream.Position = 0;
-            using var image = ImageSharp.Image.Load(stream, out IImageFormat imageFormat);
+            using var image = ImageSharp.Image.Load(stream);
+            stream.Position = 0;
+            IImageFormat imageFormat = ImageSharp.Image.DetectFormat(stream);
             imageFormat.Name.Should().Be("PNG");
         }
 

--- a/tests/Barcoder.Renderer.Svg.Tests/Barcoder.Renderer.Svg.Tests.csproj
+++ b/tests/Barcoder.Renderer.Svg.Tests/Barcoder.Renderer.Svg.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Barcoder.Tests/Barcoder.Tests.csproj
+++ b/tests/Barcoder.Tests/Barcoder.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
The ImageSharp dependency was upgraded to version 2.1 to address the MissingMethodException thrown when the project has a reference to a newer version of ImageSharp.

Refactor some tests because ImageSharp 2.x had some break changes with the previous version.